### PR TITLE
Use reference-style links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,30 @@ Project Resilience's platform for decision makers, data scientists and the publi
 
 Select a Sustainable Development Goal (SDG) from the list below to view projects for that goal.
 
+<!-- Note: using reference-style links to let Jekyll's relative links
+convert them to .html in GitHub pages -->
+[goal_01_link]: goals/goal_01.md
+[goal_02_link]: goals/goal_02.md
+[goal_03_link]: goals/goal_03.md
+[goal_04_link]: goals/goal_04.md
+[goal_05_link]: goals/goal_05.md
+[goal_06_link]: goals/goal_06.md
+[goal_07_link]: goals/goal_07.md
+[goal_08_link]: goals/goal_08.md
+[goal_09_link]: goals/goal_09.md
+[goal_10_link]: goals/goal_10.md
+[goal_11_link]: goals/goal_11.md
+[goal_12_link]: goals/goal_12.md
+[goal_13_link]: goals/goal_13.md
+[goal_14_link]: goals/goal_14.md
+[goal_15_link]: goals/goal_15.md
+[goal_16_link]: goals/goal_16.md
+[goal_17_link]: goals/goal_17.md
 
-| [![Goal 01](images/sdgs/E-WEB-Goal-01.png)](goals/goal_01.md) | [![Goal 02](images/sdgs/E-WEB-Goal-02.png)](goals/goal_02.md) | [![Goal 03](images/sdgs/E-WEB-Goal-03.png)](goals/goal_03.md) |
-|---------------------------------------------------------------|---------------------------------------------------------------|---------------------------------------------------------------|
-| [![Goal 04](images/sdgs/E-WEB-Goal-04.png)](goals/goal_04.md) | [![Goal 05](images/sdgs/E-WEB-Goal-05.png)](goals/goal_05.md) | [![Goal 06](images/sdgs/E-WEB-Goal-06.png)](goals/goal_06.md) |
-| [![Goal 07](images/sdgs/E-WEB-Goal-07.png)](goals/goal_07.md) | [![Goal 08](images/sdgs/E-WEB-Goal-08.png)](goals/goal_08.md) | [![Goal 09](images/sdgs/E-WEB-Goal-09.png)](goals/goal_09.md) |
-| [![Goal 10](images/sdgs/E-WEB-Goal-10.png)](goals/goal_10.md) | [![Goal 11](images/sdgs/E-WEB-Goal-11.png)](goals/goal_11.md) | [![Goal 12](images/sdgs/E-WEB-Goal-12.png)](goals/goal_12.md) |
-| [![Goal 13](images/sdgs/E-WEB-Goal-13.png)](goals/goal_13.md) | [![Goal 14](images/sdgs/E-WEB-Goal-14.png)](goals/goal_14.md) | [![Goal 15](images/sdgs/E-WEB-Goal-15.png)](goals/goal_15.md) |
-| [![Goal 16](images/sdgs/E-WEB-Goal-16.png)](goals/goal_16.md) | [![Goal 17](images/sdgs/E-WEB-Goal-17.png)](goals/goal_17.md) | [![Goal ALL](images/sdgs/global-goals.png)](README.md)        |
+| [![Goal 01](images/sdgs/E-WEB-Goal-01.png)][goal_01_link] | [![Goal 02](images/sdgs/E-WEB-Goal-02.png)][goal_02_link] | [![Goal 03](images/sdgs/E-WEB-Goal-03.png)][goal_03_link] |
+|-----------------------------------------------------------|-----------------------------------------------------------|-----------------------------------------------------------|
+| [![Goal 04](images/sdgs/E-WEB-Goal-04.png)][goal_04_link] | [![Goal 05](images/sdgs/E-WEB-Goal-05.png)][goal_05_link] | [![Goal 06](images/sdgs/E-WEB-Goal-06.png)][goal_06_link] |
+| [![Goal 07](images/sdgs/E-WEB-Goal-07.png)][goal_07_link] | [![Goal 08](images/sdgs/E-WEB-Goal-08.png)][goal_08_link] | [![Goal 09](images/sdgs/E-WEB-Goal-09.png)][goal_09_link] |
+| [![Goal 10](images/sdgs/E-WEB-Goal-10.png)][goal_10_link] | [![Goal 11](images/sdgs/E-WEB-Goal-11.png)][goal_11_link] | [![Goal 12](images/sdgs/E-WEB-Goal-12.png)][goal_12_link] |
+| [![Goal 13](images/sdgs/E-WEB-Goal-13.png)][goal_13_link] | [![Goal 14](images/sdgs/E-WEB-Goal-14.png)][goal_14_link] | [![Goal 15](images/sdgs/E-WEB-Goal-15.png)][goal_15_link] |
+| [![Goal 16](images/sdgs/E-WEB-Goal-16.png)][goal_16_link] | [![Goal 17](images/sdgs/E-WEB-Goal-17.png)][goal_17_link] | [![Goal ALL](images/sdgs/global-goals.png)](README.md)    |


### PR DESCRIPTION
Use reference-style links to let jekyll-relative-links convert them to .html in GitHub pages
In README.md only for now